### PR TITLE
Replace backward slashes on project path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,7 +83,7 @@ export function activate(context: vscode.ExtensionContext) {
 				else {
 					for (let i = 0; i < message.projects.length; i++) {
 						let project = message.projects[i];
-						let args = [message.command, project.projectPath, "package", message.package.id];
+						let args = [message.command, project.projectPath.replace(/\\/g, "/"), "package", message.package.id];
 						if (message.command === 'add') {
 							args.push("-v");
 							args.push(message.version);


### PR DESCRIPTION
Replaced backward slashes so *nix terminals (and GitBash/Windows) don't escape characters on the project file path, leading to an error.