### PR TITLE
Load .fsproj projects as well as .csproj

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ function readCredentials(configuration: vscode.WorkspaceConfiguration, source: s
 }
 
 function loadProjects(panel: vscode.WebviewPanel) {
-	vscode.workspace.findFiles("**/*.csproj").then(files => {
+	vscode.workspace.findFiles("**/*.{csproj,fsproj}").then(files => {
 		let projects = Array();
 		files.map(x => x.fsPath).forEach(x => {
 			let project = parseProject(x);


### PR DESCRIPTION
I just discovered this extension and it seems great, but it doesn't seem to work for .fsproj projects.

I believe the fix using a [glob pattern to match either](https://code.visualstudio.com/api/references/vscode-api#GlobPattern) .csproj or .fsproj should work given that the schema is almost the same, although I was not able to run the extension in debug (I performed `yarn install` within the workspace and web folder).