### PR TITLE
Fixed credentialProviderFolder path with space

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,10 +21,10 @@ function postMessage(panel: vscode.WebviewPanel, command: string, payload: objec
 function readCredentials(configuration: vscode.WorkspaceConfiguration, source: string, credentialsCallback: Function) {
 	let command = "";
 	if (process.platform === 'win32') {
-		command = configuration.credentialProviderFolder + "/CredentialProvider.Microsoft.exe";
+		command = "\"" + configuration.credentialProviderFolder + "/CredentialProvider.Microsoft.exe\"";
 	}
 	else {
-		command = "dotnet " + configuration.credentialProviderFolder + "/CredentialProvider.Microsoft.dll";
+		command = "dotnet \"" + configuration.credentialProviderFolder + "/CredentialProvider.Microsoft.dll\"";
 	}
 	exec(command + " -C -F Json -U " + source, function callback(error: any, stdout: any, stderr: any) {
 		console.log(stderr)


### PR DESCRIPTION
[readCredentials](https://github.com/pcislo/vscode-nuget-gallery/blob/development/src/extension.ts#L21) breaks when provided with `configuration.credentialProviderFolder` that contains spaces.
Temporary solution is to escape every space separately  (`C:\"Program Files (x86)"\"Example Folder"\Example`). This pull request fixes this issue thus eliminates needs for manual escape.